### PR TITLE
fix: resolve TruffleHog BASE/HEAD same commit error

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -88,10 +88,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run TruffleHog OSS
+      - name: Run TruffleHog OSS (PR)
+        if: github.event_name == 'pull_request'
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: main
+          base: ${{ github.event.repository.default_branch }}
           head: HEAD
+          extra_args: --debug --only-verified
+
+      - name: Run TruffleHog OSS (Push/Schedule)
+        if: github.event_name != 'pull_request'
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
           extra_args: --debug --only-verified


### PR DESCRIPTION
- Split TruffleHog step into conditional branches for PR vs push/schedule
- PR: Compare against base branch for differential scanning
- Push/Schedule: Full repository scan without base/head comparison
- Prevents 'BASE and HEAD commits are the same' error on main branch